### PR TITLE
Fix comment hotkey

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>source.ahk</string>
+	<string>source.ahk2</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
The scope is listed as `source.ahk2` in `AutoHotkey2.sublime-syntax`.
https://github.com/gwenreynolds94/SublimeAHKv2Syntax/blob/78d8f1bef257a9e1c03f6ab62ee4a86612557952/AutoHotkey2.sublime-syntax#L175

It is listed as `source.ahk` in `Comments.tmPreferences`.
https://github.com/gwenreynolds94/SublimeAHKv2Syntax/blob/78d8f1bef257a9e1c03f6ab62ee4a86612557952/Comments.tmPreferences#L8

Changing the latter into `source.ahk2` fixes the comment hotkeys for this language, allowing the (default) hotkeys `Ctrl-/` and `Ctrl-Shift-/` to add or remove line and block comment formatting.

Note that `source.ahk` is already in use by [SublimeAutoHotkey](https://github.com/ahkscript/SublimeAutoHotkey), and I have no idea if this would have been a conflict.